### PR TITLE
Don't crash when summarizing result with non-utf8 filenames

### DIFF
--- a/neopitool/neopi.py
+++ b/neopitool/neopi.py
@@ -542,6 +542,13 @@ def get_json_summary_using_all_tests(path, number_of_results=10):
 
     locator = SearchFile()
     for data, filename in locator.search_file_path([path], valid_regex):
+        # Filename might be encoded in an encoding other than utf-8 (or ascii),
+        # which will cause problems when trying to json.dumps, which attempts
+        # to encode all data as utf-8. We try to decode filenames as utf-8 here
+        # and replace any characters we cannot decode with '?' (as we have no
+        # reliable way to detect what encoding it is in) so that the end-user
+        # will get a mostly-legible filename)
+        filename = filename.decode('utf-8', errors='replace')
         for test in all_tests:
             test.calculate(data, filename)
 


### PR DESCRIPTION
JSON dumping would previously fail because it attempted an implicit
decode encode cycle. By explicitly decoding the path we end up with a
unicode object that we can encoding using any character encoding we like
(json.dumps will use utf-8), preventing an exception such as this:

```
Traceback (most recent call last):
  File "neo.py", line 3, in <module>
    data = neopitool.neopi.get_json_summary_using_all_tests('data')
  File "/home/nick/.virtualenvs/NeoPI-Tasks/src/neopitool/neopitool/neopi.py", line 566, in get_json_summary_using_all_tests
    return json.dumps(results)
  File "/usr/lib/python2.7/json/__init__.py", line 243, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xeb in position 21: invalid continuation byte
```

Should fix the outstanding issues on bug [708](http://bugs.byte.nl/view.php?id=708).
